### PR TITLE
Domain Interfaces & Custom Results

### DIFF
--- a/kbus-core/src/commonMain/kotlin/Command.kt
+++ b/kbus-core/src/commonMain/kotlin/Command.kt
@@ -9,7 +9,7 @@ abstract class Command : Message() {
 interface CommandHandler<
     TCommand : Command,
     TReturn : Any?,
-    TFailure : ResultFailure,
+    TFailure : FailureReason,
 > : MessageHandler<TCommand>, ResultReturningHandler<TCommand, TReturn, TFailure> {
     override suspend fun handle(message: TCommand): BusResult<TReturn, TFailure>
 }

--- a/kbus-core/src/commonMain/kotlin/Command.kt
+++ b/kbus-core/src/commonMain/kotlin/Command.kt
@@ -6,8 +6,12 @@ abstract class Command : Message() {
     override val messageType: String = "command"
 }
 
-interface CommandHandler<TCommand : Command, TReturn : Any?> : MessageHandler<TCommand> {
-    override suspend fun handle(message: TCommand): TReturn
+interface CommandHandler<
+    TCommand : Command,
+    TReturn : Any?,
+    TFailure : ResultFailure,
+> : MessageHandler<TCommand>, ResultReturningHandler<TCommand, TReturn, TFailure> {
+    override suspend fun handle(message: TCommand): BusResult<TReturn, TFailure>
 }
 
 class TooManyHandlersException(

--- a/kbus-core/src/commonMain/kotlin/Locker.kt
+++ b/kbus-core/src/commonMain/kotlin/Locker.kt
@@ -2,7 +2,6 @@ package com.jimbroze.kbus.core
 
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.yield
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.plus
@@ -53,9 +52,10 @@ class BusLocker(private val clock: Clock, private val defaultTimeout: Float = 5.
         if (busLocked) {
             if (inLockingCoroutine(coroutineId)) {
                 postponeHandling(message, nextMiddleware)
-                return BusResult.failure<Unit, BusLockedFailure>(BusLockedFailure(
+                return BusResult.failure<Unit, BusLockedFailure>(
+                    listOf(BusLockedFailure(
                     "Cannot handle message as message bus is locked by the same coroutine"
-                ))
+                )))
             }
         }
 
@@ -113,5 +113,5 @@ class BusLocker(private val clock: Clock, private val defaultTimeout: Float = 5.
     }
 }
 
-class BusLockedFailure(message: String? = null) : ResultFailure(message)
+class BusLockedFailure(message: String? = null) : FailureReason(message)
 

--- a/kbus-core/src/commonMain/kotlin/Locker.kt
+++ b/kbus-core/src/commonMain/kotlin/Locker.kt
@@ -53,7 +53,9 @@ class BusLocker(private val clock: Clock, private val defaultTimeout: Float = 5.
         if (busLocked) {
             if (inLockingCoroutine(coroutineId)) {
                 postponeHandling(message, nextMiddleware)
-                return Unit
+                return BusResult.failure<Unit, BusLockedFailure>(BusLockedFailure(
+                    "Cannot handle message as message bus is locked by the same coroutine"
+                ))
             }
         }
 
@@ -110,3 +112,6 @@ class BusLocker(private val clock: Clock, private val defaultTimeout: Float = 5.
         return coroutineContext[Job]?.toString() ?: ""
     }
 }
+
+class BusLockedFailure(message: String? = null) : ResultFailure(message)
+

--- a/kbus-core/src/commonMain/kotlin/Locker.kt
+++ b/kbus-core/src/commonMain/kotlin/Locker.kt
@@ -53,9 +53,10 @@ class BusLocker(private val clock: Clock, private val defaultTimeout: Float = 5.
             if (inLockingCoroutine(coroutineId)) {
                 postponeHandling(message, nextMiddleware)
                 return BusResult.failure<Unit, BusLockedFailure>(
-                    listOf(BusLockedFailure(
-                    "Cannot handle message as message bus is locked by the same coroutine"
-                )))
+                    BusLockedFailure(
+                        "Cannot handle message as message bus is locked by the same coroutine"
+                    )
+                )
             }
         }
 

--- a/kbus-core/src/commonMain/kotlin/Logging.kt
+++ b/kbus-core/src/commonMain/kotlin/Logging.kt
@@ -37,7 +37,11 @@ interface LoggingCommand : LoggingMessage {
     override val pastVerb: String get() = "executed"
 }
 
-// TODO add query. Change verb to 'process'?
+interface LoggingQuery : LoggingMessage {
+    override val finiteVerb: String get() = "process"
+    override val presentVerb: String get() = "processing"
+    override val pastVerb: String get() = "processed"
+}
 
 interface LoggingEvent : LoggingMessage {
     override val finiteVerb: String get() = "dispatch"

--- a/kbus-core/src/commonMain/kotlin/Logging.kt
+++ b/kbus-core/src/commonMain/kotlin/Logging.kt
@@ -37,6 +37,8 @@ interface LoggingCommand : LoggingMessage {
     override val pastVerb: String get() = "executed"
 }
 
+// TODO add query. Change verb to 'process'?
+
 interface LoggingEvent : LoggingMessage {
     override val finiteVerb: String get() = "dispatch"
     override val presentVerb: String get() = "dispatching"
@@ -56,7 +58,7 @@ class MessageLogger(private val logger: Logger) : Middleware {
             val result = nextMiddleware(message)
             logger.info(message.postHandleLog())
             result
-        } catch (ex: Exception) {
+        } catch (ex: Exception) { // TODO catch runtime & throwable
             logger.error(message.errorLog())
             throw ex
         }

--- a/kbus-core/src/commonMain/kotlin/MessageBus.kt
+++ b/kbus-core/src/commonMain/kotlin/MessageBus.kt
@@ -24,7 +24,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
 //        return result(commandBus, command)
 //    }
 
-    suspend fun <TCommand : Command, TReturn : Any?, TFailure : ResultFailure> execute(
+    suspend fun <TCommand : Command, TReturn : Any?, TFailure : FailureReason> execute(
         command: TCommand,
         handler: CommandHandler<TCommand, TReturn, TFailure>,
     ): BusResult<TReturn, TFailure> {
@@ -34,7 +34,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
         return result(commandBus, command)
     }
 
-    suspend fun <TQuery : Query, TReturn : Any, TFailure : ResultFailure> execute(
+    suspend fun <TQuery : Query, TReturn : Any, TFailure : FailureReason> execute(
         query: TQuery,
         handler: QueryHandler<TQuery, TReturn, TFailure>,
     ): BusResult<TReturn, TFailure> {
@@ -110,11 +110,11 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
 //        handler: CommandHandler<TCommand, TReturn>,
 //        messageType: KClass<TCommand>,
 
-    private suspend fun <TMessage : Message, TReturn : Any?, TException : ResultFailure> result(
+    private suspend fun <TMessage : Message, TReturn : Any?, TFailure : FailureReason> result(
         messageBus: MiddlewareHandler<TMessage>,
         message: TMessage
-    ): BusResult<TReturn, TException> {
+    ): BusResult<TReturn, TFailure> {
         @Suppress("UNCHECKED_CAST")
-        return messageBus(message) as BusResult<TReturn, TException>
+        return messageBus(message) as BusResult<TReturn, TFailure>
     }
 }

--- a/kbus-core/src/commonMain/kotlin/MessageBus.kt
+++ b/kbus-core/src/commonMain/kotlin/MessageBus.kt
@@ -114,6 +114,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
         messageBus: MiddlewareHandler<TMessage>,
         message: TMessage
     ): BusResult<TReturn, TFailure> {
+        // TODO remove unchecked cast by adding Type params to middleware?
         @Suppress("UNCHECKED_CAST")
         return messageBus(message) as BusResult<TReturn, TFailure>
     }

--- a/kbus-core/src/commonMain/kotlin/Query.kt
+++ b/kbus-core/src/commonMain/kotlin/Query.kt
@@ -7,7 +7,7 @@ abstract class Query : Message() {
 interface QueryHandler<
     TQuery : Query,
     TReturn : Any?,
-    TFailure : ResultFailure,
+    TFailure : FailureReason,
 > : MessageHandler<TQuery>, ResultReturningHandler<TQuery, TReturn, TFailure> {
     override suspend fun handle(message: TQuery): BusResult<TReturn, TFailure>
 }

--- a/kbus-core/src/commonMain/kotlin/Query.kt
+++ b/kbus-core/src/commonMain/kotlin/Query.kt
@@ -4,6 +4,10 @@ abstract class Query : Message() {
     override val messageType: String = "query"
 }
 
-interface QueryHandler<TQuery : Query, TReturn : Any> : MessageHandler<TQuery> {
-    override suspend fun handle(message: TQuery): TReturn
+interface QueryHandler<
+    TQuery : Query,
+    TReturn : Any?,
+    TFailure : ResultFailure,
+> : MessageHandler<TQuery>, ResultReturningHandler<TQuery, TReturn, TFailure> {
+    override suspend fun handle(message: TQuery): BusResult<TReturn, TFailure>
 }

--- a/kbus-core/src/commonMain/kotlin/Result.kt
+++ b/kbus-core/src/commonMain/kotlin/Result.kt
@@ -1,12 +1,12 @@
 package com.jimbroze.kbus.core
 
-sealed class BusResult<out TValue, out TFailure : ResultFailure>() {
-    internal class Success<TValue, TFailure : ResultFailure>(internal val value: TValue) : BusResult<TValue, TFailure>() {
+sealed class BusResult<out TValue, out TFailure : FailureReason> {
+    internal class Success<TValue, TFailure : FailureReason>(internal val value: TValue) : BusResult<TValue, TFailure>() {
         override fun toString(): String = "Success($value)"
     }
 
-    internal class Failure<TValue, TFailure : ResultFailure>(internal val exception: TFailure) : BusResult<TValue, TFailure>() {
-        override fun toString(): String = "Failure($exception)"
+    internal class Failure<TValue, TFailure : FailureReason>(internal val failureReasons: List<TFailure>) : BusResult<TValue, TFailure>() {
+        override fun toString(): String = "Failure(${failureReasons.joinToString(", ")})"
     }
 
     val isSuccess: Boolean get() = this is Success
@@ -18,41 +18,43 @@ sealed class BusResult<out TValue, out TFailure : ResultFailure>() {
             else -> null
         }
 
-    fun exceptionOrNull(): TFailure? =
+    fun exceptions(): List<TFailure> =
         when (this) {
-            is Failure -> exception
-            else -> null
+            is Failure -> failureReasons
+            else -> emptyList()
         }
 
     companion object {
-        fun <TValue, TFailure : ResultFailure> success(value: TValue): BusResult<TValue, TFailure>
+        fun <TValue, TFailure : FailureReason> success(value: TValue): BusResult<TValue, TFailure>
             = Success(value)
-        fun <TValue, TFailure : ResultFailure> failure(exception: TFailure): BusResult<TValue, TFailure> =
-            Failure(exception)
+        fun <TValue, TFailure : FailureReason> failure(exceptions: List<TFailure>): BusResult<TValue, TFailure> =
+            Failure(exceptions)
     }
 }
 
-// TODO change to allow multiple errors
-abstract class ResultFailure(val message: String? = null)
+abstract class FailureReason(val message: String? = null) {
+    override fun toString(): String = message ?: ""
+}
 
-class GenericFailure(message: String?) : ResultFailure(message)
+class GenericFailure(message: String?) : FailureReason(message)
 
 interface ResultReturningHandler<
     TMessage : Message,
     TReturn : Any?,
-    TFailure : ResultFailure,
+    TFailure : FailureReason,
 > : MessageHandler<TMessage> {
     override suspend fun handle(message: TMessage): BusResult<TReturn, TFailure>
 
     fun success(returnValue: TReturn): BusResult<TReturn, TFailure> = BusResult.success(returnValue)
     fun success(): BusResult<Unit, TFailure> = BusResult.success(Unit)
-    fun failure(exception: TFailure): BusResult<TReturn, TFailure> = BusResult.failure(exception)
-    fun failure(message: String): BusResult<TReturn, GenericFailure> = BusResult.failure(GenericFailure(message))
+    fun failure(exceptions: List<TFailure>): BusResult<TReturn, TFailure> = BusResult.failure(exceptions)
+    fun failure(exception: TFailure): BusResult<TReturn, TFailure> = BusResult.failure(listOf(exception))
+    fun failure(message: String): BusResult<TReturn, GenericFailure> = BusResult.failure(listOf(GenericFailure(message)))
 }
 
 // Example of a specific service result
 
-sealed class UserServiceException(message: String?) : ResultFailure(message) {
+sealed class UserServiceException(message: String?) : FailureReason(message) {
     class UserNotFound(message: String?) : UserServiceException(message)
     class InvalidCredentials(message: String?) : UserServiceException(message)
     class DatabaseError(message: String?) : UserServiceException(message)

--- a/kbus-core/src/commonMain/kotlin/Result.kt
+++ b/kbus-core/src/commonMain/kotlin/Result.kt
@@ -1,5 +1,60 @@
 package com.jimbroze.kbus.core
 
-class ResultFailureException(message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause) {
-    constructor(cause: Throwable) : this(null, cause)
+sealed class BusResult<out TValue, out TFailure : ResultFailure>() {
+    internal class Success<TValue, TFailure : ResultFailure>(internal val value: TValue) : BusResult<TValue, TFailure>() {
+        override fun toString(): String = "Success($value)"
+    }
+
+    internal class Failure<TValue, TFailure : ResultFailure>(internal val exception: TFailure) : BusResult<TValue, TFailure>() {
+        override fun toString(): String = "Failure($exception)"
+    }
+
+    val isSuccess: Boolean get() = this is Success
+    val isFailure: Boolean get() = this is Failure
+
+    fun getOrNull(): TValue? =
+        when (this) {
+            is Success -> value
+            else -> null
+        }
+
+    fun exceptionOrNull(): TFailure? =
+        when (this) {
+            is Failure -> exception
+            else -> null
+        }
+
+    companion object {
+        fun <TValue, TFailure : ResultFailure> success(value: TValue): BusResult<TValue, TFailure>
+            = Success(value)
+        fun <TValue, TFailure : ResultFailure> failure(exception: TFailure): BusResult<TValue, TFailure> =
+            Failure(exception)
+    }
+}
+
+// TODO change to allow multiple errors
+abstract class ResultFailure(val message: String? = null)
+
+class GenericFailure(message: String?) : ResultFailure(message)
+
+interface ResultReturningHandler<
+    TMessage : Message,
+    TReturn : Any?,
+    TFailure : ResultFailure,
+> : MessageHandler<TMessage> {
+    override suspend fun handle(message: TMessage): BusResult<TReturn, TFailure>
+
+    fun success(returnValue: TReturn): BusResult<TReturn, TFailure> = BusResult.success(returnValue)
+    fun success(): BusResult<Unit, TFailure> = BusResult.success(Unit)
+    fun failure(exception: TFailure): BusResult<TReturn, TFailure> = BusResult.failure(exception)
+    fun failure(message: String): BusResult<TReturn, GenericFailure> = BusResult.failure(GenericFailure(message))
+}
+
+// Example of a specific service result
+
+sealed class UserServiceException(message: String?) : ResultFailure(message) {
+    class UserNotFound(message: String?) : UserServiceException(message)
+    class InvalidCredentials(message: String?) : UserServiceException(message)
+    class DatabaseError(message: String?) : UserServiceException(message)
+    // Add more specific exceptions as needed
 }

--- a/kbus-core/src/commonMain/kotlin/RuntimeDependencyLoader.kt
+++ b/kbus-core/src/commonMain/kotlin/RuntimeDependencyLoader.kt
@@ -33,7 +33,7 @@ class RuntimeLoadedMessageBus(
         register(messageType, loadedHandlers)
     }
 
-    suspend fun <TCommand : Command, TReturn : Any?, TFailure : ResultFailure> execute(
+    suspend fun <TCommand : Command, TReturn : Any?, TFailure : FailureReason> execute(
         command: TCommand,
         handlerType: KClass<CommandHandler<TCommand, TReturn, TFailure>>,
     ): BusResult<TReturn, TFailure> {

--- a/kbus-core/src/commonMain/kotlin/RuntimeDependencyLoader.kt
+++ b/kbus-core/src/commonMain/kotlin/RuntimeDependencyLoader.kt
@@ -33,11 +33,13 @@ class RuntimeLoadedMessageBus(
         register(messageType, loadedHandlers)
     }
 
-    suspend fun <TCommand : Command, TReturn : Any?> execute(
+    suspend fun <TCommand : Command, TReturn : Any?, TFailure : ResultFailure> execute(
         command: TCommand,
-        handlerType: KClass<CommandHandler<TCommand, TReturn>>,
-    ): Result<TReturn> {
+        handlerType: KClass<CommandHandler<TCommand, TReturn, TFailure>>,
+    ): BusResult<TReturn, TFailure> {
         val handler = loader.load(handlerType)
         return this.execute(command, handler)
     }
+
+    // TODO add query
 }

--- a/kbus-core/src/commonMain/kotlin/domain/Entity.kt
+++ b/kbus-core/src/commonMain/kotlin/domain/Entity.kt
@@ -1,0 +1,15 @@
+package com.jimbroze.kbus.core.domain
+
+interface Identifier {
+    override fun equals(other: Any?): Boolean
+}
+
+abstract class Entity<T : Entity<T>> : HasInvariants() {
+    abstract val id: Identifier
+
+    fun hasSameIdentityAs(other: T): Boolean {
+        return id == other.id
+    }
+}
+
+abstract class AggregateRoot<T : AggregateRoot<T>> : Entity<T>()

--- a/kbus-core/src/commonMain/kotlin/domain/Invariants.kt
+++ b/kbus-core/src/commonMain/kotlin/domain/Invariants.kt
@@ -1,5 +1,7 @@
 package com.jimbroze.kbus.core.domain
 
+import com.jimbroze.kbus.core.*
+
 open class InvalidInvariantException(override val message: String) : RuntimeException(message)
 
 abstract class HasInvariants {
@@ -8,5 +10,22 @@ abstract class HasInvariants {
     }
     protected fun assert(invariant: Boolean, exception: InvalidInvariantException) {
         if (!invariant) throw exception
+    }
+}
+
+interface InvariantCatchingMessage
+
+class InvalidInvariantCatcher : Middleware {
+    override suspend fun <TMessage : Message> handle(
+        message: TMessage,
+        nextMiddleware: MiddlewareHandler<TMessage>
+    ): Any? {
+        if (message !is InvariantCatchingMessage) return nextMiddleware(message)
+
+        return try {
+            nextMiddleware(message)
+        } catch (e: InvalidInvariantException) {
+            throw ResultFailureException(e)
+        }
     }
 }

--- a/kbus-core/src/commonMain/kotlin/domain/Invariants.kt
+++ b/kbus-core/src/commonMain/kotlin/domain/Invariants.kt
@@ -1,0 +1,12 @@
+package com.jimbroze.kbus.core.domain
+
+open class InvalidInvariantException(override val message: String) : RuntimeException(message)
+
+abstract class HasInvariants {
+    protected fun assert(invariant: Boolean, message: String) {
+        if (!invariant) throw InvalidInvariantException(message)
+    }
+    protected fun assert(invariant: Boolean, exception: InvalidInvariantException) {
+        if (!invariant) throw exception
+    }
+}

--- a/kbus-core/src/commonMain/kotlin/domain/Invariants.kt
+++ b/kbus-core/src/commonMain/kotlin/domain/Invariants.kt
@@ -25,7 +25,8 @@ class InvalidInvariantCatcher : Middleware {
         return try {
             nextMiddleware(message)
         } catch (e: InvalidInvariantException) {
-            throw ResultFailureException(e)
+//            throw ResultFailure(e.message)
+            throw e //FIXME what should we do with InvalidInvariantExceptions?
         }
     }
 }

--- a/kbus-core/src/commonMain/kotlin/domain/ValueObject.kt
+++ b/kbus-core/src/commonMain/kotlin/domain/ValueObject.kt
@@ -1,0 +1,9 @@
+package com.jimbroze.kbus.core.domain
+
+abstract class ValueObject<T : ValueObject<T>> : HasInvariants() {
+    abstract override fun equals(other: Any?): Boolean
+
+    fun hasSameValueAs(other: T): Boolean {
+        return equals(other)
+    }
+}

--- a/kbus-core/src/commonTest/kotlin/LoadedCommandTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LoadedCommandTest.kt
@@ -7,9 +7,9 @@ import kotlin.test.assertEquals
 
 class UnloadedCommand(val messageData: String) : Command()
 
-class UnloadedCommandHandler(val clock: Clock) : CommandHandler<UnloadedCommand, Any> {
-    override suspend fun handle(message: UnloadedCommand): Any {
-        return message.messageData
+class UnloadedCommandHandler(val clock: Clock) : CommandHandler<UnloadedCommand, Any, ResultFailure> {
+    override suspend fun handle(message: UnloadedCommand): BusResult<Any, ResultFailure> {
+        return success(message.messageData)
     }
 }
 
@@ -37,7 +37,7 @@ class CompileTimeLoadedMessageBus(
     middleware: List<Middleware>,
     private val loader: CompileTimeGeneratedLoader,
 ) : MessageBus(middleware) {
-    suspend fun execute(loadedCommand: UnloadedCommandLoaded): Result<Any> {
+    suspend fun execute(loadedCommand: UnloadedCommandLoaded): BusResult<Any, ResultFailure> {
         val handler: UnloadedCommandHandler = this.loader.getUnloadedCommandHandler()
         return this.execute(loadedCommand.command, handler)
     }

--- a/kbus-core/src/commonTest/kotlin/LoadedCommandTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LoadedCommandTest.kt
@@ -7,8 +7,8 @@ import kotlin.test.assertEquals
 
 class UnloadedCommand(val messageData: String) : Command()
 
-class UnloadedCommandHandler(val clock: Clock) : CommandHandler<UnloadedCommand, Any, ResultFailure> {
-    override suspend fun handle(message: UnloadedCommand): BusResult<Any, ResultFailure> {
+class UnloadedCommandHandler(val clock: Clock) : CommandHandler<UnloadedCommand, Any, FailureReason> {
+    override suspend fun handle(message: UnloadedCommand): BusResult<Any, FailureReason> {
         return success(message.messageData)
     }
 }
@@ -37,7 +37,7 @@ class CompileTimeLoadedMessageBus(
     middleware: List<Middleware>,
     private val loader: CompileTimeGeneratedLoader,
 ) : MessageBus(middleware) {
-    suspend fun execute(loadedCommand: UnloadedCommandLoaded): BusResult<Any, ResultFailure> {
+    suspend fun execute(loadedCommand: UnloadedCommandLoaded): BusResult<Any, FailureReason> {
         val handler: UnloadedCommandHandler = this.loader.getUnloadedCommandHandler()
         return this.execute(loadedCommand.command, handler)
     }

--- a/kbus-core/src/commonTest/kotlin/LockingTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LockingTest.kt
@@ -94,7 +94,7 @@ class LockingTest {
         val postNest = resultMap["post-nest"]
 
         assertIs<BusResult<Any?, FailureReason>>(nestValue)
-        val nestException = nestValue.exceptions().first()
+        val nestException = nestValue.failureReasonOrNull()
         assertIs<BusLockedFailure>(nestException)
         assertEquals(
             "Cannot handle message as message bus is locked by the same coroutine",

--- a/kbus-core/src/commonTest/kotlin/LoggingTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LoggingTest.kt
@@ -32,9 +32,10 @@ class TimeCaptureLogger : Logger {
 
 class LoggingLogCommand(val messageToLog: String, val logger: Logger) : Command(), LoggingCommand
 
-class LoggingLogCommandHandler : CommandHandler<LoggingLogCommand, Unit> {
-    override suspend fun handle(message: LoggingLogCommand): Unit {
+class LoggingLogCommandHandler : CommandHandler<LoggingLogCommand, Unit, ResultFailure> {
+    override suspend fun handle(message: LoggingLogCommand): BusResult<Unit, ResultFailure> {
         message.logger.info(message.messageToLog)
+        return success()
     }
 }
 
@@ -42,8 +43,8 @@ class LoggingStorageEvent(message: String, listStore: MutableList<String>) : Sto
 
 class LoggingExceptionCommand : Command(), LoggingCommand
 
-class ExceptionCommandHandler : CommandHandler<Command, Unit> {
-    override suspend fun handle(message: Command) {
+class ExceptionCommandHandler : CommandHandler<Command, Unit, ResultFailure> {
+    override suspend fun handle(message: Command): BusResult<Unit, ResultFailure> {
         throw Exception("Exception raised")
     }
 }

--- a/kbus-core/src/commonTest/kotlin/LoggingTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LoggingTest.kt
@@ -32,8 +32,8 @@ class TimeCaptureLogger : Logger {
 
 class LoggingLogCommand(val messageToLog: String, val logger: Logger) : Command(), LoggingCommand
 
-class LoggingLogCommandHandler : CommandHandler<LoggingLogCommand, Unit, ResultFailure> {
-    override suspend fun handle(message: LoggingLogCommand): BusResult<Unit, ResultFailure> {
+class LoggingLogCommandHandler : CommandHandler<LoggingLogCommand, Unit, FailureReason> {
+    override suspend fun handle(message: LoggingLogCommand): BusResult<Unit, FailureReason> {
         message.logger.info(message.messageToLog)
         return success()
     }
@@ -43,8 +43,8 @@ class LoggingStorageEvent(message: String, listStore: MutableList<String>) : Sto
 
 class LoggingExceptionCommand : Command(), LoggingCommand
 
-class ExceptionCommandHandler : CommandHandler<Command, Unit, ResultFailure> {
-    override suspend fun handle(message: Command): BusResult<Unit, ResultFailure> {
+class ExceptionCommandHandler : CommandHandler<Command, Unit, FailureReason> {
+    override suspend fun handle(message: Command): BusResult<Unit, FailureReason> {
         throw Exception("Exception raised")
     }
 }

--- a/kbus-core/src/commonTest/kotlin/MessageBusTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MessageBusTest.kt
@@ -108,7 +108,7 @@ class MessageBusTest {
         assertEquals("The command failed", failureReasons[0].message)
         assertIs<BrokenStateFailure>(failureReasons[1])
         assertEquals("Illegal state in command handling", failureReasons[1].message)
-        assertEquals("Failure(The command failed, Illegal state in command handling)", result.toString())
+        assertEquals("Failure(There were multiple failures)", result.toString())
     }
 
     @Test

--- a/kbus-core/src/commonTest/kotlin/MessageBusTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MessageBusTest.kt
@@ -73,7 +73,7 @@ class MessageBusTest {
         val result = bus.execute(FailureCommand(), GenericFailureCommandHandler())
 
         assertTrue(result.isFailure)
-        val failure = result.exceptions().first()
+        val failure = result.failureReasonOrNull()
         assertIs<FailureReason>(failure)
         assertEquals("The command failed", failure.message)
         assertEquals("Failure(The command failed)", result.toString())
@@ -86,7 +86,7 @@ class MessageBusTest {
         val result = bus.execute(FailureCommand(), BrokenStateFailureCommandHandler())
 
         assertTrue(result.isFailure)
-        val failure = result.exceptions().first()
+        val failure = result.failureReasonOrNull()
         assertIs<BrokenStateFailure>(failure)
         assertEquals("Illegal state in command handling", failure.message)
         assertEquals("Failure(Illegal state in command handling)", result.toString())
@@ -99,12 +99,15 @@ class MessageBusTest {
         val result = bus.execute(FailureCommand(), MultipleFailureCommandHandler())
 
         assertTrue(result.isFailure)
-        val failures = result.exceptions()
-        assertEquals(2, failures.size)
-        assertIs<GenericFailure>(failures[0])
-        assertEquals("The command failed", failures[0].message)
-        assertIs<BrokenStateFailure>(failures[1])
-        assertEquals("Illegal state in command handling", failures[1].message)
+
+        assertIs<BusResult<Any?, MultipleFailureReasons>>(result)
+        val failureReasons = result.failureReasonOrNull()!!.reasons
+
+        assertEquals(2, failureReasons.size)
+        assertIs<GenericFailure>(failureReasons[0])
+        assertEquals("The command failed", failureReasons[0].message)
+        assertIs<BrokenStateFailure>(failureReasons[1])
+        assertEquals("Illegal state in command handling", failureReasons[1].message)
         assertEquals("Failure(The command failed, Illegal state in command handling)", result.toString())
     }
 
@@ -126,7 +129,7 @@ class MessageBusTest {
         val result = bus.execute(FailureQuery(), FailureQueryHandler())
 
         assertTrue(result.isFailure)
-        val failure = result.exceptions().first()
+        val failure = result.failureReasonOrNull()
         assertIs<FailureReason>(failure)
         assertEquals("The query failed", failure.message)
     }

--- a/kbus-core/src/commonTest/kotlin/MessageStoreTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MessageStoreTest.kt
@@ -5,22 +5,24 @@ import kotlin.test.*
 
 class ReturnCommand(val messageData: String) : Command()
 
-class ReturnCommandHandler : CommandHandler<ReturnCommand, Any> {
-    override suspend fun handle(message: ReturnCommand): Any {
-        return message.messageData
+class ReturnCommandHandler : CommandHandler<ReturnCommand, Any, GenericFailure> {
+    override suspend fun handle(message: ReturnCommand): BusResult<Any, GenericFailure> {
+        return success(message.messageData)
     }
 }
 
 open class StorageCommand(val messageData: String, val listStore: MutableList<String>) : Command()
 
-class StorageCommandHandler : CommandHandler<StorageCommand, Unit> {
-    override suspend fun handle(message: StorageCommand) {
+class StorageCommandHandler : CommandHandler<StorageCommand, Unit, GenericFailure> {
+    override suspend fun handle(message: StorageCommand): BusResult<Unit, GenericFailure> {
         message.listStore.add(message.messageData)
+        return success()
     }
 }
 
-class AnyCommandHandler : CommandHandler<Command, Unit> {
-    override suspend fun handle(message: Command) {
+class AnyCommandHandler : CommandHandler<Command, Unit, GenericFailure> {
+    override suspend fun handle(message: Command): BusResult<Unit, GenericFailure> {
+        return success()
     }
 }
 
@@ -52,7 +54,8 @@ class TestMessageStore {
 
         val result = bus.handle(ReturnCommand("Testing"), listOf(ReturnCommandHandler()))
 
-        assertEquals("Testing", result)
+        assertIs<BusResult<Any?, ResultFailure>>(result)
+        assertEquals("Testing", result.getOrNull())
     }
 
     @Test
@@ -62,7 +65,8 @@ class TestMessageStore {
 
         val result = bus.handle(ReturnCommand("Testing"))
 
-        assertEquals("Testing", result)
+        assertIs<BusResult<Any?, ResultFailure>>(result)
+        assertEquals("Testing", result.getOrNull())
     }
 
     @Test

--- a/kbus-core/src/commonTest/kotlin/MessageStoreTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MessageStoreTest.kt
@@ -54,7 +54,7 @@ class TestMessageStore {
 
         val result = bus.handle(ReturnCommand("Testing"), listOf(ReturnCommandHandler()))
 
-        assertIs<BusResult<Any?, ResultFailure>>(result)
+        assertIs<BusResult<Any?, FailureReason>>(result)
         assertEquals("Testing", result.getOrNull())
     }
 
@@ -65,7 +65,7 @@ class TestMessageStore {
 
         val result = bus.handle(ReturnCommand("Testing"))
 
-        assertIs<BusResult<Any?, ResultFailure>>(result)
+        assertIs<BusResult<Any?, FailureReason>>(result)
         assertEquals("Testing", result.getOrNull())
     }
 

--- a/kbus-core/src/commonTest/kotlin/MiddlewareTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MiddlewareTest.kt
@@ -11,7 +11,7 @@ class MiddlewareTest {
     @Test
     fun test_MessageLogger_logs_and_executes_command() = runTest {
         val captureLogger = CaptureLogger()
-        val bus = MessageBus(listOf(MessageLogger(captureLogger)))
+        val bus = MessageBus(listOf(MessageLogger(captureLogger, LogLevels.DEBUG, LogLevels.INFO, LogLevels.ERROR)))
 
         bus.execute(LoggingLogCommand("Test the bus", CaptureLogger()), LoggingLogCommandHandler())
 
@@ -25,8 +25,8 @@ class MiddlewareTest {
         val bus =
             MessageBus(
                 listOf(
-                    MessageLogger(logger1),
-                    MessageLogger(logger2),
+                    MessageLogger(logger1, LogLevels.DEBUG, LogLevels.INFO, LogLevels.ERROR),
+                    MessageLogger(logger2, LogLevels.DEBUG, LogLevels.INFO, LogLevels.ERROR),
                 ),
             )
 

--- a/kbus-core/src/commonTest/kotlin/domain/EntityTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/EntityTest.kt
@@ -1,0 +1,35 @@
+package com.jimbroze.kbus.core.domain
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EntityTest {
+    @Test
+    fun test_Entity_with_same_ids_match() {
+        val entity1 = TestEntity(TestIdentifier(1))
+        val entity2 = TestEntity(TestIdentifier(1))
+
+        val identical = entity1.hasSameIdentityAs(entity2)
+
+        assertTrue(identical)
+    }
+
+    @Test
+    fun test_Entity_with_different_ids_do_not_match() {
+        val entity1 = TestEntity(TestIdentifier(1))
+        val entity2 = TestEntity(TestIdentifier(2))
+
+        val identical = entity1.hasSameIdentityAs(entity2)
+
+        assertFalse(identical)
+    }
+
+    @Test
+    fun test_false_assertion_throws_invalid_invariant_exception() {
+        assertFailsWith<InvalidInvariantException>("ID must be no greater than 5") {
+            val entity = TestEntityWithMaxIdOfFive(TestIdentifier(6))
+        }
+    }
+}

--- a/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
@@ -14,8 +14,8 @@ class InvalidInvariantsCatchingCommand(
     exception: InvalidInvariantException,
 ) : InvalidInvariantsCommand(exception), InvariantCatchingMessage
 
-class InvalidInvariantsCommandHandler : CommandHandler<InvalidInvariantsCommand, Unit, ResultFailure> {
-    override suspend fun handle(message: InvalidInvariantsCommand): BusResult<Unit, ResultFailure> {
+class InvalidInvariantsCommandHandler : CommandHandler<InvalidInvariantsCommand, Unit, FailureReason> {
+    override suspend fun handle(message: InvalidInvariantsCommand): BusResult<Unit, FailureReason> {
         throw message.exception
     }
 }

--- a/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
@@ -1,0 +1,68 @@
+package com.jimbroze.kbus.core.domain
+
+import com.jimbroze.kbus.core.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class InvalidInvariantExample(message: String) : InvalidInvariantException(message)
+
+open class InvalidInvariantsCommand(
+    val exception: InvalidInvariantException,
+) : Command()
+
+class InvalidInvariantsCatchingCommand(
+    exception: InvalidInvariantException,
+) : InvalidInvariantsCommand(exception), InvariantCatchingMessage
+
+class InvalidInvariantsCommandHandler : CommandHandler<InvalidInvariantsCommand, Unit> {
+    override suspend fun handle(message: InvalidInvariantsCommand) {
+        throw message.exception
+    }
+}
+
+class InvariantsTest {
+    @Test
+    fun invariant_catcher_only_processes_invariant_catching_message() = runTest {
+        val catcher = InvalidInvariantCatcher()
+
+        assertFailsWith<InvalidInvariantException>("Failure message"){
+            catcher.handle(
+                InvalidInvariantsCommand(
+                    InvalidInvariantException("Failure message")
+                )
+            ) {
+                InvalidInvariantsCommandHandler().handle(it)
+            }
+        }
+    }
+
+    @Test
+    fun invariant_catcher_converts_invalid_invariant_exception_to_result_failure() = runTest {
+        val catcher = InvalidInvariantCatcher()
+
+        assertFailsWith<ResultFailureException>("Failure message"){
+            catcher.handle(
+                InvalidInvariantsCatchingCommand(
+                    InvalidInvariantException("Failure message")
+                )
+            ) {
+                InvalidInvariantsCommandHandler().handle(it)
+            }
+        }
+    }
+
+    @Test
+    fun invariant_catcher_converts_invalid_invariant_exception_subclass_to_result_failure() = runTest {
+        val catcher = InvalidInvariantCatcher()
+
+        assertFailsWith<ResultFailureException>("Failure message"){
+            catcher.handle(
+                InvalidInvariantsCatchingCommand(
+                    InvalidInvariantExample("Failure message")
+                )
+            ) {
+                InvalidInvariantsCommandHandler().handle(it)
+            }
+        }
+    }
+}

--- a/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
@@ -4,7 +4,13 @@ import com.jimbroze.kbus.core.*
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-class InvalidInvariantExample(message: String) : InvalidInvariantException(message)
+sealed class TwoPossibleInvariants(message: String) : InvalidInvariantException(message) {
+    class OneInvariantException(message: String) : TwoPossibleInvariants(message)
+    class TwoInvariantExceptions(message: String) : TwoPossibleInvariants(message)
+}
+
+class FailureOne(cause: InvalidInvariantException) : InvalidInvariantFailure(cause)
+class FailureTwo(cause: InvalidInvariantException) : InvalidInvariantFailure(cause)
 
 open class InvalidInvariantsCommand(
     val exception: InvalidInvariantException,
@@ -12,7 +18,27 @@ open class InvalidInvariantsCommand(
 
 class InvalidInvariantsCatchingCommand(
     exception: InvalidInvariantException,
-) : InvalidInvariantsCommand(exception), InvariantCatchingMessage
+) : InvalidInvariantsCommand(exception), InvariantCatchingMessage {
+    override fun handleException(exception: InvalidInvariantException): FailureReason {
+        return when (exception) {
+            is TwoPossibleInvariants.OneInvariantException -> FailureOne(exception)
+            is TwoPossibleInvariants.TwoInvariantExceptions -> FailureTwo(exception)
+            else -> throw exception
+        }
+    }
+}
+
+class MultipleInvalidInvariantsCatchingCommand(
+    exception: InvalidInvariantException,
+) : InvalidInvariantsCommand(exception), InvariantCatchingMessage {
+    override fun handleException(exception: InvalidInvariantException): FailureReason {
+        if (exception !is TwoPossibleInvariants) throw exception
+        return when (exception) {
+            is TwoPossibleInvariants.OneInvariantException -> FailureOne(exception)
+            is TwoPossibleInvariants.TwoInvariantExceptions -> FailureTwo(exception)
+        }
+    }
+}
 
 class InvalidInvariantsCommandHandler : CommandHandler<InvalidInvariantsCommand, Unit, FailureReason> {
     override suspend fun handle(message: InvalidInvariantsCommand): BusResult<Unit, FailureReason> {
@@ -40,29 +66,40 @@ class InvariantsTest {
     fun invariant_catcher_converts_invalid_invariant_exception_to_result_failure() = runTest {
         val catcher = InvalidInvariantCatcher()
 
-        assertFailsWith<InvalidInvariantException>("Failure message"){
-            catcher.handle(
-                InvalidInvariantsCatchingCommand(
-                    InvalidInvariantException("Failure message")
-                )
-            ) {
-                InvalidInvariantsCommandHandler().handle(it)
-            }
+        val result = catcher.handle(
+            InvalidInvariantsCatchingCommand(
+                TwoPossibleInvariants.OneInvariantException("Failure message one")
+            )
+        ) {
+            InvalidInvariantsCommandHandler().handle(it)
         }
+
+        assertIs<BusResult<Any?, FailureReason>>(result)
+        val failureReason = result.failureReasonOrNull()
+
+        assertIs<InvalidInvariantFailure>(failureReason)
+        assertEquals("Failure message one", failureReason.message)
     }
 
     @Test
-    fun invariant_catcher_converts_invalid_invariant_exception_subclass_to_result_failure() = runTest {
+    fun invariant_catcher_converts_multiple_invalid_invariant_exception_to_result_failures() = runTest {
         val catcher = InvalidInvariantCatcher()
 
-        assertFailsWith<InvalidInvariantException>("Failure message"){
-            catcher.handle(
-                InvalidInvariantsCatchingCommand(
-                    InvalidInvariantExample("Failure message")
-                )
-            ) {
-                InvalidInvariantsCommandHandler().handle(it)
-            }
+        val result = catcher.handle(
+            MultipleInvalidInvariantsCatchingCommand(
+                MultipleInvalidInvariantsException(errors = listOf(
+                    TwoPossibleInvariants.OneInvariantException("Failure message"),
+                    TwoPossibleInvariants.TwoInvariantExceptions("Other failure message"),
+                ))
+            )
+        ) {
+            InvalidInvariantsCommandHandler().handle(it)
         }
+
+        assertIs<BusResult<Any?, MultipleFailureReasons>>(result)
+        val failureReasons = result.failureReasonOrNull()!!.reasons
+        assertEquals(2, failureReasons.size)
+        assertEquals("Failure message", failureReasons[0].message)
+        assertEquals("Other failure message", failureReasons[1].message)
     }
 }

--- a/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
@@ -14,8 +14,8 @@ class InvalidInvariantsCatchingCommand(
     exception: InvalidInvariantException,
 ) : InvalidInvariantsCommand(exception), InvariantCatchingMessage
 
-class InvalidInvariantsCommandHandler : CommandHandler<InvalidInvariantsCommand, Unit> {
-    override suspend fun handle(message: InvalidInvariantsCommand) {
+class InvalidInvariantsCommandHandler : CommandHandler<InvalidInvariantsCommand, Unit, ResultFailure> {
+    override suspend fun handle(message: InvalidInvariantsCommand): BusResult<Unit, ResultFailure> {
         throw message.exception
     }
 }
@@ -40,7 +40,7 @@ class InvariantsTest {
     fun invariant_catcher_converts_invalid_invariant_exception_to_result_failure() = runTest {
         val catcher = InvalidInvariantCatcher()
 
-        assertFailsWith<ResultFailureException>("Failure message"){
+        assertFailsWith<InvalidInvariantException>("Failure message"){
             catcher.handle(
                 InvalidInvariantsCatchingCommand(
                     InvalidInvariantException("Failure message")
@@ -55,7 +55,7 @@ class InvariantsTest {
     fun invariant_catcher_converts_invalid_invariant_exception_subclass_to_result_failure() = runTest {
         val catcher = InvalidInvariantCatcher()
 
-        assertFailsWith<ResultFailureException>("Failure message"){
+        assertFailsWith<InvalidInvariantException>("Failure message"){
             catcher.handle(
                 InvalidInvariantsCatchingCommand(
                     InvalidInvariantExample("Failure message")

--- a/kbus-core/src/commonTest/kotlin/domain/Testfixtures.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/Testfixtures.kt
@@ -1,0 +1,36 @@
+package com.jimbroze.kbus.core.domain
+
+class TestIdentifier(val intId: Int) : Identifier {
+    override fun equals(other: Any?): Boolean {
+        return other is TestIdentifier && intId == other.intId
+    }
+
+    override fun hashCode(): Int {
+        return intId
+    }
+}
+
+class TestEntity(override val id: TestIdentifier) : Entity<TestEntity>()
+class TestEntityWithMaxIdOfFive(override val id: TestIdentifier) : Entity<TestEntity>() {
+    init {
+        assert(id.intId <= 5, "ID must be no greater than 5")
+    }
+}
+
+open class TestValueObject(val data: String) : ValueObject<TestValueObject>() {
+    override fun equals(other: Any?): Boolean {
+        return other is TestValueObject && data == other.data
+    }
+
+    override fun hashCode(): Int {
+        return data.hashCode()
+    }
+}
+
+class CannotBeEmptyException : InvalidInvariantException("Value Object cannot be empty")
+
+class TestNonEmptyValueObject(data: String) : TestValueObject(data) {
+    init {
+        assert(data.isNotEmpty(), CannotBeEmptyException())
+    }
+}

--- a/kbus-core/src/commonTest/kotlin/domain/ValueObjectTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/ValueObjectTest.kt
@@ -1,0 +1,39 @@
+package com.jimbroze.kbus.core.domain
+
+import kotlin.test.*
+
+class ValueObjectTest {
+    @Test
+    fun test_ValueObject_with_same_values_match() {
+        val valueObject1 = TestValueObject("howdy")
+        val valueObject2 = TestValueObject("howdy")
+
+        val sameValue = valueObject1.hasSameValueAs(valueObject2)
+
+        assertTrue(sameValue)
+        assertEquals(valueObject1, valueObject2)
+        assertNotSame(valueObject1, valueObject2)
+    }
+
+    @Test
+    fun test_ValueObject_with_different_values_do_not_match() {
+        val valueObject1 = TestValueObject("howdy")
+        val valueObject2 = TestValueObject("aye up")
+
+        val sameValue = valueObject1.hasSameValueAs(valueObject2)
+
+        assertFalse(sameValue)
+        assertNotEquals(valueObject1, valueObject2)
+        assertNotSame(valueObject1, valueObject2)
+    }
+
+    @Test
+    fun test_false_assertion_throws_invalid_invariant_exception() {
+        assertFailsWith<CannotBeEmptyException>("Value Object cannot be empty") {
+            val valueObject = TestNonEmptyValueObject("")
+        }
+        assertFailsWith<InvalidInvariantException>("Value Object cannot be empty") {
+            val valueObject = TestNonEmptyValueObject("")
+        }
+    }
+}

--- a/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
@@ -11,8 +11,8 @@ class TestGeneratorCommand(val messageData: String) : Command()
 class TestGeneratorCommandHandler(
     private val locker: BusLocker,
     private val clock: Clock
-) : CommandHandler<TestGeneratorCommand, Any, ResultFailure> {
-    override suspend fun handle(message: TestGeneratorCommand): BusResult<Any, ResultFailure> {
+) : CommandHandler<TestGeneratorCommand, Any, FailureReason> {
+    override suspend fun handle(message: TestGeneratorCommand): BusResult<Any, FailureReason> {
         return success(message.messageData + clock.now().toString())
     }
 }
@@ -23,8 +23,8 @@ class TestDuplicateGeneratorCommand(val messageData: String) : Command()
 class TestDuplicateGeneratorCommandHandler(
     private val clock: Clock,
     private val bus: MessageBus,
-) : CommandHandler<TestDuplicateGeneratorCommand, Any, ResultFailure> {
-    override suspend fun handle(message: TestDuplicateGeneratorCommand): BusResult<Any, ResultFailure> {
+) : CommandHandler<TestDuplicateGeneratorCommand, Any, FailureReason> {
+    override suspend fun handle(message: TestDuplicateGeneratorCommand): BusResult<Any, FailureReason> {
         return success(message.messageData + clock.now().toString())
     }
 }

--- a/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
@@ -28,3 +28,15 @@ class TestDuplicateGeneratorCommandHandler(
         return success(message.messageData + clock.now().toString())
     }
 }
+
+class TestGeneratorQuery(val messageData: String) : Query()
+
+@Load
+class TestGeneratorQueryHandler(
+    private val locker: BusLocker,
+    private val clock: Clock
+) : QueryHandler<TestGeneratorQuery, Any, FailureReason> {
+    override suspend fun handle(message: TestGeneratorQuery): BusResult<Any, FailureReason> {
+        return success(message.messageData + clock.now().toString())
+    }
+}

--- a/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
@@ -1,10 +1,7 @@
 package com.jimbroze.kbus.generation.test
 
 import com.jimbroze.kbus.annotations.Load
-import com.jimbroze.kbus.core.BusLocker
-import com.jimbroze.kbus.core.Command
-import com.jimbroze.kbus.core.CommandHandler
-import com.jimbroze.kbus.core.MessageBus
+import com.jimbroze.kbus.core.*
 import kotlinx.datetime.Clock
 
 
@@ -14,9 +11,9 @@ class TestGeneratorCommand(val messageData: String) : Command()
 class TestGeneratorCommandHandler(
     private val locker: BusLocker,
     private val clock: Clock
-) : CommandHandler<TestGeneratorCommand, Any> {
-    override suspend fun handle(message: TestGeneratorCommand): Any {
-        return message.messageData + clock.now().toString()
+) : CommandHandler<TestGeneratorCommand, Any, ResultFailure> {
+    override suspend fun handle(message: TestGeneratorCommand): BusResult<Any, ResultFailure> {
+        return success(message.messageData + clock.now().toString())
     }
 }
 
@@ -26,8 +23,8 @@ class TestDuplicateGeneratorCommand(val messageData: String) : Command()
 class TestDuplicateGeneratorCommandHandler(
     private val clock: Clock,
     private val bus: MessageBus,
-) : CommandHandler<TestDuplicateGeneratorCommand, Any> {
-    override suspend fun handle(message: TestDuplicateGeneratorCommand): Any {
-        return message.messageData + clock.now().toString()
+) : CommandHandler<TestDuplicateGeneratorCommand, Any, ResultFailure> {
+    override suspend fun handle(message: TestDuplicateGeneratorCommand): BusResult<Any, ResultFailure> {
+        return success(message.messageData + clock.now().toString())
     }
 }

--- a/kbus-generation-test/src/commonTest/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonTest/kotlin/GenerationTest.kt
@@ -2,6 +2,7 @@ package com.jimbroze.kbus.generation
 
 import com.jimbroze.kbus.core.*
 import com.jimbroze.kbus.generation.test.TestGeneratorCommandLoaded
+import com.jimbroze.kbus.generation.test.TestGeneratorQueryLoaded
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
@@ -36,6 +37,25 @@ class GenerationTest {
         )
 
         val result = bus.execute(TestGeneratorCommandLoaded("The time is "))
+
+        assertEquals("The time is 2024-02-23T19:01:09Z", result.getOrNull())
+    }
+
+    @Test
+    fun test_execute_executes_a_query() = runTest {
+        val clock = FixedClock(Instant.parse("2024-02-23T19:01:09Z"))
+        class Dependencies : GeneratedDependencies {
+            override fun getLocker() = BusLocker(clock)
+            override fun getClock(): Clock = clock
+            override fun getBus() = MessageBus()
+        }
+
+        val bus = CompileTimeLoadedMessageBus(
+            emptyList(),
+            CompileTimeGeneratedLoader(Dependencies())
+        )
+
+        val result = bus.execute(TestGeneratorQueryLoaded("The time is "))
 
         assertEquals("The time is 2024-02-23T19:01:09Z", result.getOrNull())
     }

--- a/kbus-generation/src/commonMain/kotlin/DependencyLoaderGenerator.kt
+++ b/kbus-generation/src/commonMain/kotlin/DependencyLoaderGenerator.kt
@@ -1,0 +1,129 @@
+package com.jimbroze.kbus.generation
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.jimbroze.kbus.core.MessageBus
+
+object DependencyLoaderGenerator {
+    fun generateDependencyLoader(
+        codeGenerator: CodeGenerator,
+        visitorContext: LoadedMessageCode,
+    ) {
+        val packageName = MessageBus::class.qualifiedName!!.split(".").dropLast(1).joinToString(".")
+
+        val fileText = generateLoaderCode(
+            packageName,
+            visitorContext.handlerDependencies,
+            visitorContext.loaderMethods,
+            visitorContext.busMethods,
+        )
+
+        val file = codeGenerator.createNewFile(
+            Dependencies(true),
+            packageName,
+            "GeneratedDependencyLoader"
+        )
+        file.write(fileText.toString().toByteArray())
+        file.close()
+    }
+
+    private fun generateLoaderCode(
+        packageName: String,
+        handlerDependencies: Set<ParameterDefinition>,
+        loaderMethods: StringBuilder,
+        busMethods: StringBuilder,
+    ): StringBuilder {
+        val fileText = StringBuilder()
+
+        fileText.appendLine("package $packageName")
+        fileText.appendLine()
+        fileText.append(generateDependenciesInterface(handlerDependencies))
+        fileText.append(generateLoaderClasses(loaderMethods))
+        fileText.append(generateBusClass(busMethods))
+
+        return fileText
+    }
+
+    fun addMethodToBusClass(classDefinition: LoadedHandlerDefinition): StringBuilder {
+        val busMethodCode = StringBuilder()
+
+        val messageType = classDefinition.handlerDefinition.messageBaseClass.simpleName!!
+        val messageTypeLowercase = messageType.lowercase()
+
+        val handlerName = classDefinition.handlerDefinition.handler.simpleName.asString()
+        val loadedMessageName = classDefinition.loadedMessageName
+
+        busMethodCode.appendLine(
+            "    suspend fun execute(loaded$messageType: $loadedMessageName)"
+        )
+        busMethodCode.appendLine(
+            "        = this.execute(loaded$messageType.$messageTypeLowercase, this.loader.get$handlerName())"
+        )
+
+        return busMethodCode
+    }
+
+    private fun generateBusClass(busMethods: StringBuilder): StringBuilder {
+        // TODO use MessageBus constructor for type safety? Replace pre-written class instead?
+
+        val busClassCode = StringBuilder()
+        busClassCode.appendLine("class CompileTimeLoadedMessageBus(")
+        busClassCode.appendLine("    middleware: List<Middleware>,")
+        busClassCode.appendLine("    private val loader: CompileTimeGeneratedLoader,")
+        busClassCode.appendLine(") : MessageBus(middleware) {")
+
+        busClassCode.append(busMethods)
+
+        busClassCode.appendLine("}")
+
+        return busClassCode
+    }
+
+    private fun generateDependenciesInterface(allHandlerDependencies: Set<ParameterDefinition>): StringBuilder {
+        val dependenciesInterfaceCode = StringBuilder()
+
+        dependenciesInterfaceCode.appendLine("interface GeneratedDependencies {")
+        for (dependency in allHandlerDependencies) {
+            val dependencyName = dependency.name.replaceFirstChar { it.uppercase() }
+            dependenciesInterfaceCode.appendLine("    fun get$dependencyName(): ${dependency.typeName}")
+        }
+        dependenciesInterfaceCode.appendLine("}")
+
+        return dependenciesInterfaceCode
+    }
+
+    fun addMethodToLoaderClass(classDefinition: LoadedHandlerDefinition): StringBuilder {
+        val loaderMethodCode = StringBuilder()
+
+        val handlerDependencies =
+            classDefinition.handlerDefinition.handler.primaryConstructor!!.parameters.map { getParamNames(it) }
+        val handlerDependenciesString = StringBuilder()
+        var firstParam = true
+        for (dependency in handlerDependencies) {
+            val dependencyName = dependency.name.replaceFirstChar { it.uppercase() }
+            handlerDependenciesString.append("${if (firstParam) "" else ", "}this.dependencies.get$dependencyName()")
+            firstParam = false
+        }
+        val handlerName = classDefinition.handlerDefinition.handler.simpleName.asString()
+        val handlerType = classDefinition.handlerDefinition.handler.qualifiedName!!.asString()
+
+        loaderMethodCode.appendLine("    fun get$handlerName(): $handlerType {")
+        loaderMethodCode.appendLine("        return $handlerType($handlerDependenciesString)")
+        loaderMethodCode.appendLine("    }")
+
+        return loaderMethodCode
+    }
+
+    private fun generateLoaderClasses(loaderMethods: StringBuilder): StringBuilder {
+        val stringBuilder = StringBuilder()
+        stringBuilder.appendLine(
+            "class CompileTimeGeneratedLoader(private val dependencies: GeneratedDependencies) {"
+        )
+
+        stringBuilder.append(loaderMethods)
+
+        stringBuilder.appendLine("}")
+
+        return stringBuilder
+    }
+}

--- a/kbus-generation/src/commonMain/kotlin/LoadedMessageGenerator.kt
+++ b/kbus-generation/src/commonMain/kotlin/LoadedMessageGenerator.kt
@@ -1,0 +1,116 @@
+package com.jimbroze.kbus.generation
+
+import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.jimbroze.kbus.core.Message
+import kotlin.reflect.KClass
+
+class LoadedMessageGenerator(
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger,
+    private val loadableMessages: List<KClass<out Message>>
+) {
+    fun generateLoadedMessage(handlerClass: KSClassDeclaration): LoadedHandlerDefinition? {
+        val messageDefinition = messageForHandler(handlerClass) ?: return null
+
+        return createLoadedMessage(messageDefinition, handlerClass)
+    }
+
+    private fun messageForHandler(handlerClass: KSClassDeclaration): HandlerDefinition? {
+        // TODO improve finding handle function. Need to get override and check that command handler?
+        val possibleHandleMethods = handlerClass.getDeclaredFunctions()
+            .filter {
+                it.simpleName.asString() == "handle"
+                        && it.parameters.count() == 1
+            }
+
+        var messageClass: KSClassDeclaration? = null
+        var messageType: KClass<out Message>? = null
+        for (handleFunction in possibleHandleMethods) {
+            val messageSubClass = handleFunction
+                .parameters.first()
+                .type.resolve().declaration
+
+            if (messageSubClass !is KSClassDeclaration) {
+                continue
+            }
+
+            val messageTypeDeclaration = findBaseClass(messageSubClass) ?: continue
+            messageType = loadableMessages
+                .find { it.qualifiedName == messageTypeDeclaration.qualifiedName?.asString() } ?: continue
+
+            if (messageClass !== null) {
+                logger.error(
+                    "Multiple valid 'handle' functions found for handler",
+                    handlerClass
+                )
+                return null
+            }
+
+            messageClass = messageSubClass
+        }
+
+
+        if (messageClass == null || messageType == null) {
+            logger.error("Message handler must have a valid 'handle' function.", handlerClass)
+            return null
+        }
+
+        return HandlerDefinition(handlerClass, messageClass, messageType)
+    }
+
+    private fun createLoadedMessage(
+        messageDefinition: HandlerDefinition,
+        classDeclaration: KSClassDeclaration,
+    ): LoadedHandlerDefinition {
+        val message = messageDefinition.message
+        val handler: KSClassDeclaration = classDeclaration
+        val messageTypeLowercase = messageDefinition.messageBaseClass.simpleName.toString().lowercase()
+
+        // TODO test for different packages?
+        val packageName = handler.containingFile!!.packageName.asString()
+        val messageClassName = message.simpleName.asString()
+        val handlerClassName = handler.simpleName.asString()
+        val loadedClassName = "${messageClassName}Loaded"
+
+        val loadedMessageConstructorParameters = StringBuilder()
+        val messageConstructorParameters = StringBuilder()
+        var firstParam = true
+        //            TODO handler null constructor?
+        for (messageParameter in message.primaryConstructor?.parameters!!) {
+            val messageParameterNames = getParamNames(messageParameter)
+            val name = messageParameterNames.name
+            val typeName = messageParameterNames.typeName
+
+            loadedMessageConstructorParameters.append("${if (firstParam) "" else ", "}$name: $typeName")
+            messageConstructorParameters.append("${if (firstParam) "" else ", "}$name")
+
+            firstParam = false
+        }
+
+        val fileText = StringBuilder()
+        fileText.appendLine("package $packageName")
+        fileText.appendLine()
+        fileText.appendLine("class $loadedClassName($loadedMessageConstructorParameters) {")
+        fileText.appendLine("    val $messageTypeLowercase = ${messageClassName}(${messageConstructorParameters})")
+        fileText.appendLine("    suspend fun handle(handler: $handlerClassName) = handler.handle($messageTypeLowercase)")
+        fileText.appendLine("}")
+
+        val file = codeGenerator.createNewFile(
+            Dependencies(true, handler.containingFile!!, message.containingFile!!),
+            packageName,
+            loadedClassName
+        )
+
+        file.write(fileText.toString().toByteArray())
+        file.close()
+
+        return LoadedHandlerDefinition(
+            messageDefinition,
+            "$packageName.$loadedClassName",
+        )
+    }
+}

--- a/kbus-generation/src/commonMain/kotlin/Utils.kt
+++ b/kbus-generation/src/commonMain/kotlin/Utils.kt
@@ -1,0 +1,35 @@
+package com.jimbroze.kbus.generation
+
+import com.google.devtools.ksp.symbol.*
+
+data class ParameterDefinition(
+    val name: String,
+    val typeName: String,
+)
+
+//TODO refactor this?
+fun getParamNames(parameter: KSValueParameter): ParameterDefinition {
+    val name = parameter.name!!.asString()
+    val typeName = StringBuilder(parameter.type.resolve().declaration.qualifiedName?.asString() ?: "<ERROR>")
+    val typeArgs = parameter.type.element!!.typeArguments
+
+    if (parameter.type.element!!.typeArguments.isNotEmpty()) {
+        typeName.append("<")
+        typeName.append(
+            typeArgs.joinToString(", ") {
+                val type = it.type?.resolve()
+                "${it.variance.label} ${type?.declaration?.qualifiedName?.asString() ?: "ERROR"}" +
+                        if (type?.nullability == Nullability.NULLABLE) "?" else ""
+            }
+        )
+        typeName.append(">")
+    }
+
+    return ParameterDefinition(name, typeName.toString())
+}
+
+fun findBaseClass(classDeclaration: KSClassDeclaration): KSClassDeclaration? {
+    return classDeclaration.superTypes
+        .mapNotNull { superType -> superType.resolve().declaration as? KSClassDeclaration }
+        .find { it.classKind == ClassKind.CLASS }
+}


### PR DESCRIPTION
- Add domain driven design abstract base classes. These can be used to add common behaviour or enforce the requirements used by entities and value objects.
- Add a custom result class that encapsulates the result of a command or query. This holds a value for successful results and a message or 'failure' for failures. Importantly, this failure object is not an exception which prevents domain leakage into the higher layers of an application. It allows the message handler to remain a boundary between the domain and the rest of the application.
- Allow catching of domain exceptions and returning specific results related to the exception. This works using an interface which ensures that exception handling is set up appropriately for a handler that uses this functionality.
- Add queries to code generation (for compile-time dependency loaders).

Other changes:
- Change logger middleware to use a single log method. This allows log levels to be completely custom rather than predefining them. This is important because there is no 'standardised' logger interface for Kotlin.
- Improve code generation for compile-time dependency loaders. This is refactoring to improve code readability and separation of concerns.