### PR TITLE
Improve Integration events

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload build reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-reports
           path: '**/build/reports'

--- a/kbus-annotations/src/commonMain/kotlin/Load.kt
+++ b/kbus-annotations/src/commonMain/kotlin/Load.kt
@@ -1,3 +1,3 @@
-package kbus.annotations
+package com.jimbroze.kbus.annotations
 
 @Target(AnnotationTarget.CLASS) annotation class Load

--- a/kbus-core/src/commonMain/kotlin/Command.kt
+++ b/kbus-core/src/commonMain/kotlin/Command.kt
@@ -6,9 +6,9 @@ abstract class Command : Message() {
     override val messageType: String = "command"
 }
 
-interface CommandHandler<TCommand : Command, TReturn : Any?, TFailure : FailureReason> :
-    MessageHandler<TCommand>, ResultReturningHandler<TCommand, TReturn, TFailure> {
-    override suspend fun handle(message: TCommand): BusResult<TReturn, TFailure>
+abstract class CommandHandler<TCommand : Command, TReturn : Any?, TFailure : FailureReason> :
+    MessageHandler<TCommand>, ResultReturningHandler<TCommand, TReturn, TFailure>, CanAccessBus() {
+    abstract override suspend fun handle(message: TCommand): BusResult<TReturn, TFailure>
 }
 
 class TooManyHandlersException(message: String = "A handler has already been registered") :

--- a/kbus-core/src/commonMain/kotlin/MessageBus.kt
+++ b/kbus-core/src/commonMain/kotlin/MessageBus.kt
@@ -30,6 +30,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
     ): BusResult<TReturn, TFailure> {
         //        ensureNoOtherCommandHandlers(command::class)
 
+        handler.bus = this
         val commandBus = getBus(commandStore, listOfNotNull(handler))
         return result(commandBus, command)
     }
@@ -116,5 +117,13 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
         // TODO remove unchecked cast by adding Type params to middleware?
         @Suppress("UNCHECKED_CAST")
         return messageBus(message) as BusResult<TReturn, TFailure>
+    }
+}
+
+abstract class CanAccessBus {
+    var bus: MessageBus? = null
+
+    suspend fun dispatch(event: Event) {
+        bus?.dispatch(event)
     }
 }

--- a/kbus-core/src/commonMain/kotlin/MessageBus.kt
+++ b/kbus-core/src/commonMain/kotlin/MessageBus.kt
@@ -1,5 +1,6 @@
 package com.jimbroze.kbus.core
 
+import kotlin.js.JsName
 import kotlin.reflect.KClass
 
 open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
@@ -24,6 +25,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
     //        return result(commandBus, command)
     //    }
 
+    @JsName("executeCommand")
     suspend fun <TCommand : Command, TReturn : Any?, TFailure : FailureReason> execute(
         command: TCommand,
         handler: CommandHandler<TCommand, TReturn, TFailure>,
@@ -35,6 +37,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
         return result(commandBus, command)
     }
 
+    @JsName("executeQuery")
     suspend fun <TQuery : Query, TReturn : Any, TFailure : FailureReason> execute(
         query: TQuery,
         handler: QueryHandler<TQuery, TReturn, TFailure>,

--- a/kbus-core/src/commonMain/kotlin/MessageBus.kt
+++ b/kbus-core/src/commonMain/kotlin/MessageBus.kt
@@ -30,7 +30,7 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
     ): BusResult<TReturn, TFailure> {
         //        ensureNoOtherCommandHandlers(command::class)
 
-        handler.bus = this
+        handler.setBus(this)
         val commandBus = getBus(commandStore, listOfNotNull(handler))
         return result(commandBus, command)
     }
@@ -121,7 +121,11 @@ open class MessageBus(val middlewares: List<Middleware> = emptyList()) {
 }
 
 abstract class CanAccessBus {
-    var bus: MessageBus? = null
+    private var bus: MessageBus? = null
+
+    fun setBus(bus: MessageBus) {
+        this.bus = bus
+    }
 
     suspend fun dispatch(event: Event) {
         bus?.dispatch(event)

--- a/kbus-core/src/commonTest/kotlin/LoadedCommandTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LoadedCommandTest.kt
@@ -8,7 +8,7 @@ import kotlinx.datetime.Clock
 class UnloadedCommand(val messageData: String) : Command()
 
 class UnloadedCommandHandler(val clock: Clock) :
-    CommandHandler<UnloadedCommand, Any, FailureReason> {
+    CommandHandler<UnloadedCommand, Any, FailureReason>() {
     override suspend fun handle(message: UnloadedCommand): BusResult<Any, FailureReason> {
         return success(message.messageData)
     }

--- a/kbus-core/src/commonTest/kotlin/LockingTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LockingTest.kt
@@ -15,7 +15,7 @@ class TimeReturnCommand(
 ) : Command()
 
 class TimeReturnCommandHandler :
-    CommandHandler<TimeReturnCommand, TimeSource.Monotonic.ValueTimeMark, FailureReason> {
+    CommandHandler<TimeReturnCommand, TimeSource.Monotonic.ValueTimeMark, FailureReason>() {
     override suspend fun handle(
         message: TimeReturnCommand
     ): BusResult<TimeSource.Monotonic.ValueTimeMark, FailureReason> {
@@ -34,7 +34,7 @@ class LockingPrintReturnCommand(
 ) : Command(), LockingCommand
 
 class LockingPrintReturnCommandHandler(private val locker: BusLocker) :
-    CommandHandler<LockingPrintReturnCommand, Any, FailureReason> {
+    CommandHandler<LockingPrintReturnCommand, Any, FailureReason>() {
     override suspend fun handle(message: LockingPrintReturnCommand): BusResult<Any, FailureReason> {
         val timeSource = TimeSource.Monotonic
         val preNestTime = timeSource.markNow()
@@ -59,7 +59,7 @@ class LockingSleepCommand(
     override val lockTimeout: Float? = null,
 ) : Command(), LockingCommand
 
-class LockingSleepCommandHandler : CommandHandler<LockingSleepCommand, Any, FailureReason> {
+class LockingSleepCommandHandler : CommandHandler<LockingSleepCommand, Any, FailureReason>() {
     override suspend fun handle(message: LockingSleepCommand): BusResult<Any, FailureReason> {
         delay((1000 * message.waitSecs).toLong())
         return success(message.messageData)
@@ -68,7 +68,7 @@ class LockingSleepCommandHandler : CommandHandler<LockingSleepCommand, Any, Fail
 
 class SleepCommand(val waitSecs: Float) : Command()
 
-class SleepCommandHandler : CommandHandler<SleepCommand, Unit, FailureReason> {
+class SleepCommandHandler : CommandHandler<SleepCommand, Unit, FailureReason>() {
     override suspend fun handle(message: SleepCommand): BusResult<Unit, FailureReason> {
         delay((1000 * message.waitSecs).toLong())
         return success()
@@ -78,7 +78,7 @@ class SleepCommandHandler : CommandHandler<SleepCommand, Unit, FailureReason> {
 class LockAdjustCommand(val messageData: String, override val lockTimeout: Float) :
     Command(), LockAdjustMessage
 
-class LockAdjustCommandHandler : CommandHandler<LockAdjustCommand, Any, FailureReason> {
+class LockAdjustCommandHandler : CommandHandler<LockAdjustCommand, Any, FailureReason>() {
     override suspend fun handle(message: LockAdjustCommand): BusResult<Any, FailureReason> {
         return success(message.messageData)
     }

--- a/kbus-core/src/commonTest/kotlin/LoggingTest.kt
+++ b/kbus-core/src/commonTest/kotlin/LoggingTest.kt
@@ -37,7 +37,7 @@ class TimeCaptureLogger : Logger {
 
 class LoggingLogCommand(val messageToLog: String, val logger: Logger) : Command(), LoggingCommand
 
-class LoggingLogCommandHandler : CommandHandler<LoggingLogCommand, Unit, FailureReason> {
+class LoggingLogCommandHandler : CommandHandler<LoggingLogCommand, Unit, FailureReason>() {
     override suspend fun handle(message: LoggingLogCommand): BusResult<Unit, FailureReason> {
         message.logger.log(LogLevels.INFO, message.messageToLog, null)
         return success()
@@ -60,7 +60,7 @@ class TestException(message: String) : Exception(message)
 
 class LoggingExceptionCommand : Command(), LoggingCommand
 
-class ExceptionCommandHandler : CommandHandler<Command, Unit, FailureReason> {
+class ExceptionCommandHandler : CommandHandler<Command, Unit, FailureReason>() {
     override suspend fun handle(message: Command): BusResult<Unit, FailureReason> {
         throw TestException("Exception raised")
     }

--- a/kbus-core/src/commonTest/kotlin/MessageBusTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MessageBusTest.kt
@@ -308,7 +308,7 @@ class MessageBusTest {
     }
 
     @Test
-    fun test_command_can_emit_integration_event() = runTest {
+    fun test_command_can_dispatch_integration_event() = runTest {
         val bus = MessageBus()
         val list = mutableListOf<String>()
         bus.register(StorageEvent::class, listOf(PrintEventHandler()))

--- a/kbus-core/src/commonTest/kotlin/MessageStoreTest.kt
+++ b/kbus-core/src/commonTest/kotlin/MessageStoreTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.runTest
 
 class ReturnCommand(val messageData: String) : Command()
 
-class ReturnCommandHandler : CommandHandler<ReturnCommand, Any, GenericFailure> {
+class ReturnCommandHandler : CommandHandler<ReturnCommand, Any, GenericFailure>() {
     override suspend fun handle(message: ReturnCommand): BusResult<Any, GenericFailure> {
         return success(message.messageData)
     }
@@ -19,14 +19,14 @@ class ReturnCommandHandler : CommandHandler<ReturnCommand, Any, GenericFailure> 
 
 open class StorageCommand(val messageData: String, val listStore: MutableList<String>) : Command()
 
-class StorageCommandHandler : CommandHandler<StorageCommand, Unit, GenericFailure> {
+class StorageCommandHandler : CommandHandler<StorageCommand, Unit, GenericFailure>() {
     override suspend fun handle(message: StorageCommand): BusResult<Unit, GenericFailure> {
         message.listStore.add(message.messageData)
         return success()
     }
 }
 
-class AnyCommandHandler : CommandHandler<Command, Unit, GenericFailure> {
+class AnyCommandHandler : CommandHandler<Command, Unit, GenericFailure>() {
     override suspend fun handle(message: Command): BusResult<Unit, GenericFailure> {
         return success()
     }

--- a/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
+++ b/kbus-core/src/commonTest/kotlin/domain/InvariantsTest.kt
@@ -46,7 +46,7 @@ class MultipleInvalidInvariantsCatchingCommand(exception: InvalidInvariantExcept
 }
 
 class InvalidInvariantsCommandHandler :
-    CommandHandler<InvalidInvariantsCommand, Unit, FailureReason> {
+    CommandHandler<InvalidInvariantsCommand, Unit, FailureReason>() {
     override suspend fun handle(message: InvalidInvariantsCommand): BusResult<Unit, FailureReason> {
         throw message.exception
     }

--- a/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
@@ -1,5 +1,6 @@
 package com.jimbroze.kbus.generation.test
 
+import com.jimbroze.kbus.annotations.Load
 import com.jimbroze.kbus.core.BusLocker
 import com.jimbroze.kbus.core.BusResult
 import com.jimbroze.kbus.core.Command
@@ -8,7 +9,6 @@ import com.jimbroze.kbus.core.FailureReason
 import com.jimbroze.kbus.core.MessageBus
 import com.jimbroze.kbus.core.Query
 import com.jimbroze.kbus.core.QueryHandler
-import kbus.annotations.Load
 import kotlinx.datetime.Clock
 
 class TestGeneratorCommand(val messageData: String) : Command()

--- a/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
@@ -15,7 +15,7 @@ class TestGeneratorCommand(val messageData: String) : Command()
 
 @Load
 class TestGeneratorCommandHandler(private val locker: BusLocker, private val clock: Clock) :
-    CommandHandler<TestGeneratorCommand, Any, FailureReason> {
+    CommandHandler<TestGeneratorCommand, Any, FailureReason>() {
     override suspend fun handle(message: TestGeneratorCommand): BusResult<Any, FailureReason> {
         locker.toString()
         return success(message.messageData + clock.now().toString())
@@ -26,7 +26,7 @@ class TestDuplicateGeneratorCommand(val messageData: String) : Command()
 
 @Load
 class TestDuplicateGeneratorCommandHandler(private val clock: Clock, private val bus: MessageBus) :
-    CommandHandler<TestDuplicateGeneratorCommand, Any, FailureReason> {
+    CommandHandler<TestDuplicateGeneratorCommand, Any, FailureReason>() {
     override suspend fun handle(
         message: TestDuplicateGeneratorCommand
     ): BusResult<Any, FailureReason> {

--- a/kbus-generation/src/commonMain/kotlin/MessageProcessor.kt
+++ b/kbus-generation/src/commonMain/kotlin/MessageProcessor.kt
@@ -10,13 +10,13 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.validate
 import com.google.devtools.ksp.visitor.KSDefaultVisitor
+import com.jimbroze.kbus.annotations.Load
 import com.jimbroze.kbus.core.Command
 import com.jimbroze.kbus.core.Message
 import com.jimbroze.kbus.core.Query
 import com.jimbroze.kbus.generation.DependencyLoaderGenerator.addMethodToBusClass
 import com.jimbroze.kbus.generation.DependencyLoaderGenerator.addMethodToLoaderClass
 import com.jimbroze.kbus.generation.DependencyLoaderGenerator.generateDependencyLoader
-import kbus.annotations.Load
 import kotlin.reflect.KClass
 
 private val loadableMessages = listOf(Command::class, Query::class)


### PR DESCRIPTION
Provide a `dispatch` method that's useable within command handlers. To achieve this, `CommandHandler` is now an abstract class rather than an interface. 