### PR TITLE
Automatically Release and Publish Library using Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Publish Artifacts
+name: Release Package Version
 on:
   push:
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: Publish Artifacts
+on:
+  push:
+    branches:
+      - main
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRIBUTION: 'corretto'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{env.JAVA_VERSION}}
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Get Gradle Project Version
+        id: gradle_version
+        run: |
+          VERSION=$(./gradlew properties | grep "version:" | cut -d' ' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          TAG_EXISTS=$(git tag -l "v${{ steps.gradle_version.outputs.version }}")
+          if [ -z "$TAG_EXISTS" ]; then
+            echo "exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "exists=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.gradle_version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload build reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-reports
           path: '**/build/reports'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Publish Artifacts
+on:
+  release:
+    types: [ published ]
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRIBUTION: 'corretto'
+  XCODE_VERSION: '15.3'
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{env.JAVA_VERSION}}
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Add Gradle Properties
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          echo "mavenCentralUsername=${MAVEN_CENTRAL_USERNAME}" >> gradle.properties
+          echo "mavenCentralPassword=${MAVEN_CENTRAL_PASSWORD}" >> gradle.properties
+          echo "signing.keyId=${SIGNING_KEY_ID}" >> gradle.properties
+          echo "signing.password=${SIGNING_KEY_PASSWORD}" >> gradle.properties
+          echo "signing.secretKeyRingFile=${HOME}/secret_key.gpg" >> gradle.properties
+
+      - name: Set up XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Setup GPG Key
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        run: |
+          brew install gpg
+          echo "$SIGNING_KEY" | gpg --dearmor > ${HOME}/secret_key.gpg
+
+      - name: Extract Release Version
+        id: version
+        run: echo "VERSION=${{ github.event.release.tag_name#v }}" >> $GITHUB_ENV
+
+      - name: Publish To Maven Central
+        env:
+          VERSION_OVERRIDE: ${{ env.VERSION }}
+        run: |
+          ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ replay_pid*
 
 .kotlin/
 !gradle-wrapper.jar
+
+secret_key.gpg

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.jimbroze"
-    version = System.getenv("VERSION_OVERRIDE") ?: "0.1.1"
+    version = System.getenv("VERSION_OVERRIDE") ?: "0.2.0"
 
     apply(plugin = "com.ncorti.ktfmt.gradle")
     ktfmt { kotlinLangStyle() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.jimbroze"
-    version = System.getenv("VERSION_OVERRIDE") ?: "0.1.0"
+    version = System.getenv("VERSION_OVERRIDE") ?: "0.1.1"
 
     apply(plugin = "com.ncorti.ktfmt.gradle")
     ktfmt { kotlinLangStyle() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 import com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask
 import io.gitlab.arturbosch.detekt.Detekt
+import java.util.*
+
+description = "Kotlin message bus framework"
 
 plugins {
     id("com.ncorti.ktfmt.gradle") version ("0.20.1")
@@ -8,6 +11,7 @@ plugins {
 
 allprojects {
     group = "com.jimbroze"
+    version = System.getenv("VERSION_OVERRIDE") ?: "0.1.0"
 
     apply(plugin = "com.ncorti.ktfmt.gradle")
     ktfmt { kotlinLangStyle() }
@@ -20,6 +24,16 @@ allprojects {
         autoCorrect = true
         parallel = true
         source.from("src")
+    }
+}
+
+val localPropertiesFile = file("local.properties")
+
+if (localPropertiesFile.exists()) {
+    val localProperties = Properties()
+    localPropertiesFile.inputStream().use { localProperties.load(it) }
+    localProperties.forEach { (key, value) ->
+        project.extensions.extraProperties[key.toString()] = value
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.jimbroze"
-    version = System.getenv("VERSION_OVERRIDE") ?: "0.2.0"
+    version = System.getenv("VERSION_OVERRIDE") ?: "0.1.1"
 
     apply(plugin = "com.ncorti.ktfmt.gradle")
     ktfmt { kotlinLangStyle() }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,10 +3,14 @@ plugins {
     id("groovy-gradle-plugin")
 }
 
-repositories { gradlePluginPortal() }
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
 
 dependencies {
     implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.maven.publish.plugin)
     // To access libs in buildSrc file
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,12 +1,12 @@
-plugins{
+plugins {
     `kotlin-dsl`
     id("groovy-gradle-plugin")
 }
 
-repositories {
-    gradlePluginPortal()
-}
+repositories { gradlePluginPortal() }
 
 dependencies {
     implementation(libs.kotlin.gradle.plugin)
+    // To access libs in buildSrc file
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -8,15 +8,11 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+
     repositories {
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-    }
-
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
     }
 }

--- a/buildSrc/src/main/kotlin/kbus.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/kbus.multiplatform.gradle.kts
@@ -1,8 +1,12 @@
-import org.gradle.accessors.dm.LibrariesForLibs
+// import org.gradle.accessors.dm.LibrariesForLibs
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.konan.target.HostManager
 
-val libs = the<LibrariesForLibs>()
+// val libs = the<LibrariesForLibs>()
+val Project.libs
+    get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
+
+// val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 plugins { kotlin("multiplatform") }
 

--- a/buildSrc/src/main/kotlin/kbus.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/kbus.multiplatform.gradle.kts
@@ -1,9 +1,16 @@
+import org.gradle.accessors.dm.LibrariesForLibs
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.konan.target.HostManager
+
+val libs = the<LibrariesForLibs>()
 
 plugins { kotlin("multiplatform") }
 
 kotlin {
+    jvmToolchain {
+        (this).languageVersion.set(JavaLanguageVersion.of(libs.versions.jdk.target.get()))
+    }
+
     js(IR) {
         //        browser()
         nodejs()

--- a/buildSrc/src/main/kotlin/kbus.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/kbus.publish.gradle.kts
@@ -1,10 +1,50 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     `maven-publish`
+    id("com.vanniktech.maven.publish")
 }
 
-publishing {
-    repositories {
-        mavenLocal()
+publishing { repositories { mavenLocal() } }
+
+// Required to get project description
+afterEvaluate {
+    mavenPublishing {
+        coordinates(
+            groupId = project.group.toString(),
+            artifactId = project.name,
+            version = project.version.toString(),
+        )
+
+        pom {
+            name.set(project.name)
+            description.set(project.description)
+            inceptionYear.set("2024")
+            url.set("https://github.com/jimbroze/kbus")
+
+            licenses {
+                license {
+                    name.set("MIT")
+                    url.set("https://opensource.org/licenses/MIT")
+                }
+            }
+
+            developers {
+                developer {
+                    id.set("jimbroze")
+                    name.set("Jim Dickinson")
+                    email.set("james.n.dickinson@gmail.com")
+                }
+            }
+
+            // Specify SCM information
+            scm { url.set("https://github.com/jimbroze/kbus") }
+        }
+
+        // Manual release ./gradlew publishToMavenCentral --no-configuration-cache
+        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        // Release with publish & publishToMavenCentral tasks
+        //        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+        signAllPublications()
     }
 }
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+jdk-target = "17"
 koinCore = "4.0.0"
 kotlin = "2.0.20"
 kotlinxCoroutinesCore = "1.9.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 jdk-target = "17"
 koinCore = "4.0.0"
-kotlin = "2.0.20"
+kotlin = "2.1.0"
 kotlinxCoroutinesCore = "1.9.0"
 kotlinxDatetime = "0.6.1"
-ksp = "2.0.20-1.0.24"
+ksp = "2.1.0-1.0.29"
+maven-publish = "0.30.0"
 
 [libraries]
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinCore" }
@@ -14,6 +15,8 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+maven-publish-plugin = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version.ref = "maven-publish" }
 
 [plugins]
 devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/kbus-annotations/build.gradle.kts
+++ b/kbus-annotations/build.gradle.kts
@@ -1,10 +1,8 @@
+description = "Annotations for use with Kbus code generation"
+
 plugins {
     id("kbus.multiplatform")
     id("kbus.publish")
 }
-
-group = "com.jimbroze"
-
-version = "1.0-SNAPSHOT"
 
 kotlin { sourceSets { commonMain.dependencies {} } }

--- a/kbus-core/build.gradle.kts
+++ b/kbus-core/build.gradle.kts
@@ -1,9 +1,9 @@
+description = "Kotlin message bus framework"
+
 plugins {
     id("kbus.multiplatform")
     id("kbus.publish")
 }
-
-version = "1.0-SNAPSHOT"
 
 kotlin {
     sourceSets {
@@ -15,8 +15,8 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
-//            implementation(project(":kbus-code-generation"))
-//            ksp(project(":kbus-code-generation"))
+            //            implementation(project(":kbus-code-generation"))
+            //            ksp(project(":kbus-code-generation"))
         }
     }
 }

--- a/kbus-generation/build.gradle.kts
+++ b/kbus-generation/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
+    jvmToolchain {
+        (this).languageVersion.set(JavaLanguageVersion.of(libs.versions.jdk.target.get()))
+    }
     jvm()
     sourceSets {
         commonMain.dependencies {

--- a/kbus-generation/build.gradle.kts
+++ b/kbus-generation/build.gradle.kts
@@ -1,10 +1,10 @@
+description = "Code generation module for Kbus: A Kotlin message bus framework"
+
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.devtools.ksp)
     id("kbus.publish")
 }
-
-version = "1.0-SNAPSHOT"
 
 kotlin {
     jvmToolchain {

--- a/kbus-koin/build.gradle.kts
+++ b/kbus-koin/build.gradle.kts
@@ -1,9 +1,9 @@
+description = "A module to use Koin with Kbus: A Kotlin message bus framework"
+
 plugins {
     id("kbus.multiplatform")
     id("kbus.publish")
 }
-
-version = "1.0-SNAPSHOT"
 
 kotlin {
     sourceSets {

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -279,6 +279,13 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+kotlin-web-helpers@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.0.0.tgz#b112096b273c1e733e0b86560998235c09a19286"
+  integrity sha512-xkVGl60Ygn/zuLkDPx+oHj7jeLR7hCvoNF99nhwXMn8a3ApB4lLiC9pk4ol4NHPjyoCbvQctBqvzUcp8pkqyWw==
+  dependencies:
+    format-util "^1.0.5"
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -301,10 +308,10 @@ minimatch@^5.0.1, minimatch@^5.1.6:
   dependencies:
     brace-expansion "^2.0.1"
 
-mocha@10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.0.tgz#9e5cbed8fa9b37537a25bd1f7fb4f6fc45458b9a"
-  integrity sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==
+mocha@10.7.3:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.3.tgz#ae32003cabbd52b59aece17846056a68eb4b0752"
+  integrity sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==
   dependencies:
     ansi-colors "^4.1.3"
     browser-stdout "^1.3.1"


### PR DESCRIPTION
- Setup publishing artifacts to Maven Central.
- Add Github Actions to:
  - Create a new Github release. This runs when deployed to main branch and only if the gradle package version has been changed to a tag that hasn't been used before.
  - Publish artifacts to Maven. This runs when a new Github release is created.