### PR TITLE
Dependency Generation: Use Handler Parameter Name as Dependency Name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.jimbroze"
-    version = System.getenv("VERSION_OVERRIDE") ?: "0.2.2"
+    version = System.getenv("VERSION_OVERRIDE") ?: "0.2.4"
 
     apply(plugin = "com.ncorti.ktfmt.gradle")
     ktfmt { kotlinLangStyle() }

--- a/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonMain/kotlin/GenerationTest.kt
@@ -87,13 +87,13 @@ class TestDuplicateGeneratorCommandHandler(
     }
 }
 
-class TestGeneratorQuery(val messageData: String) : Query()
+class TestGeneratorQuery(val messageData: String, val moreMessageData: String) : Query()
 
 @Load
 class TestGeneratorQueryHandler(private val locker: BusLocker, private val clock: Clock) :
     QueryHandler<TestGeneratorQuery, Any, FailureReason> {
     override suspend fun handle(message: TestGeneratorQuery): BusResult<Any, FailureReason> {
         locker.toString()
-        return success(message.messageData + clock.now().toString())
+        return success(message.messageData + message.moreMessageData + clock.now().toString())
     }
 }

--- a/kbus-generation-test/src/commonTest/kotlin/GenerationTest.kt
+++ b/kbus-generation-test/src/commonTest/kotlin/GenerationTest.kt
@@ -49,8 +49,8 @@ class GenerationTest {
 
         val bus = CompileTimeLoadedMessageBus(emptyList(), Dependencies(instant))
 
-        val result = bus.execute(TestGeneratorQueryLoaded("The time is "))
+        val result = bus.execute(TestGeneratorQueryLoaded("The time is ", "now "))
 
-        assertEquals("The time is 2024-02-23T19:01:09Z", result.getOrNull())
+        assertEquals("The time is now 2024-02-23T19:01:09Z", result.getOrNull())
     }
 }

--- a/kbus-generation/src/commonMain/kotlin/DependencyLoaderGenerator.kt
+++ b/kbus-generation/src/commonMain/kotlin/DependencyLoaderGenerator.kt
@@ -15,21 +15,25 @@ data class DependencyDefinition(
     val declaration: KSDeclaration,
     val typeArgs: List<KSTypeArgument>,
     val isSingleton: Boolean = true,
+    val customName: String? = null,
 ) {
     companion object {
         fun fromParameter(
             parameter: KSValueParameter,
             paramType: KSDeclaration?,
+            useParamName: Boolean = false,
         ): DependencyDefinition {
             val declaration = paramType ?: parameter.type.resolve().declaration
             val typeArgs = parameter.type.element?.typeArguments.orEmpty()
 
-            return DependencyDefinition(declaration, typeArgs)
+            val customName = if (useParamName) parameter.name?.asString() else null
+
+            return DependencyDefinition(declaration, typeArgs, customName = customName)
         }
     }
 
     fun getName(): String {
-        return declaration.simpleName.asString().replaceFirstChar { it.lowercase() }
+        return customName ?: declaration.simpleName.asString().replaceFirstChar { it.lowercase() }
     }
 
     fun getTypeWithArgs(): String {

--- a/kbus-generation/src/commonMain/kotlin/LoadedMessageGenerator.kt
+++ b/kbus-generation/src/commonMain/kotlin/LoadedMessageGenerator.kt
@@ -94,7 +94,7 @@ class LoadedMessageGenerator(
         //            TODO handler null constructor?
         for (messageParameter in message.primaryConstructor?.parameters!!) {
             val messageParameterDependency =
-                DependencyDefinition.fromParameter(messageParameter, null)
+                DependencyDefinition.fromParameter(messageParameter, null, true)
             val name = messageParameterDependency.getName()
             val typeName = messageParameterDependency.getTypeWithArgs()
 


### PR DESCRIPTION
When generating dependencies for message handlers, use the handlers' parameter name as the dependency name. Previously, the dependency type was used as the name which led to name conflicts with primitive types such as `String`.