### PR TITLE
Auto Publish on Version Update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish Artifacts
 on:
   release:
     types: [ published ]
+  workflow_call:
 
 env:
   JAVA_VERSION: '17'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 env:
   JAVA_VERSION: '17'
   JAVA_DISTRIBUTION: 'corretto'
-  XCODE_VERSION: '15.3'
+  XCODE_VERSION: '26.3'
 
 jobs:
   publish:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,11 +8,11 @@ on:
 env:
   JAVA_VERSION: '17'
   JAVA_DISTRIBUTION: 'corretto'
-  XCODE_VERSION: '15.3'
+  XCODE_VERSION: '26.3'
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      tag_exists: ${{ steps.check_tag.outputs.exists }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,3 +50,8 @@ jobs:
         with:
           tag_name: v${{ steps.gradle_version.outputs.version }}
           generate_release_notes: true
+  call-publish-workflow:
+    needs: release
+    if: needs.release.outputs.tag_exists == 'false'
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 allprojects {
     group = "com.jimbroze"
-    version = System.getenv("VERSION_OVERRIDE") ?: "0.3.0"
+    version = System.getenv("VERSION_OVERRIDE") ?: "0.3.1"
 
     apply(plugin = "com.ncorti.ktfmt.gradle")
     ktfmt { kotlinLangStyle() }


### PR DESCRIPTION
Update the CI workflows so that the `release` workflow (which automatically creates a release when a PR is merged that has a new version update) calls the `publish` workflow. This only happens if the version is updated.